### PR TITLE
[SC-1046] Try to minimize forge compilation time

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,9 +1,12 @@
 [profile.default]
 src = 'contracts'
 out = 'out'
-libs = ['node_modules', 'lib']
+libs = ['lib']
 test = 'test'
 cache_path  = 'cache_forge'
 optimizer_runs = 1000000
 via-ir = true
 gas_reports = ["Escrow", "EscrowFactory"]
+
+[profile.lite.optimizer_details.yulDetails]
+optimizerSteps = ''

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "doc": "forge doc --build --out documentation",
     "lint": "solhint --max-warnings 0 \"**/*.sol\"",
     "lint:fix": "solhint --max-warnings 0 \"**/*.sol\" --fix",
-    "test": "forge test -vvv"
+    "test": "forge test -vvv",
+    "test:lite": "FOUNDRY_PROFILE=lite forge test -vvv"
   }
 }


### PR DESCRIPTION
With the new "lite" profile compilation time is reduced from ~60s to ~20s. This profile can be used to speed up the development process (e.g. to run tests locally).