### PR TITLE
fix(DOPS-2602): update GitHub Actions to Node 24 compatible versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: 'yarn'
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
@@ -21,7 +21,7 @@ jobs:
   snapshot:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
       - name: Install Foundry
@@ -32,7 +32,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
       - name: Install Foundry
@@ -43,10 +43,10 @@ jobs:
   test-zksync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           repository: matter-labs/foundry-zksync
           ref: 'main'
@@ -59,13 +59,13 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
       - name: Run coverage
         run: yarn coverage
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
GitHub removes Node 20 from Actions runners on 2026-09-16, and since 2026-06-02 actions pinned to node20 are force-run on Node 24, so they can break at any time. Bump all node20-based actions to their Node 24 compatible majors before workflows start failing.

https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

#### Static Code Analysis (readability, compactness):

#### Dynamic Code Analysis (external APIs, interaction flows):

#### Efficiency (gas costs, computational complexity, memory requirements):

#### Opinion, trade-offs and other thoughts (optional):
